### PR TITLE
[#12] update seacore prod ci/cd to use on-prem tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,8 @@ build_production_sgnlp:
 
 build_production_seacorenlp:
   stage: build_production
+  tags:
+    - on-prem
   needs: ["deploy_staging_seacorenlp"]
   when: manual
   only:


### PR DESCRIPTION
Closes #12 

Added on-prem tags for build_production_seacorenlp build stage.
This tag is required for Gitlab CI/CD to pull the CI/CD runner from internal image registry.

See build_production_sgnlp for similar config.